### PR TITLE
Mejorado cálculo Modelo 130

### DIFF
--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -238,10 +238,7 @@ class Modelo130 extends Controller
             new DataBaseWhere('fecha', $this->dateEnd, '<='),
             
             // Para buscar ftras sólo de la empresa/Ejercicio elegido
-            new DataBaseWhere('idempresa', $this->idempresa),
-            
-            // Para buscar ftras (de clientes o de Proveedores) que tengan IRPF
-            // new DataBaseWhere('totalirpf', 0.0, '!=') ... lo quitamos porque el modelo 130 es el cálculo total de ftras ventas (todas) menos el total de ftras. compras/gastos * 20%
+            new DataBaseWhere('idempresa', $this->idempresa),            
         ];
         
 
@@ -251,10 +248,7 @@ class Modelo130 extends Controller
             new DataBaseWhere('fecha', $this->dateEnd, '<='),
             
             // Para buscar ftras sólo de la empresa/Ejercicio elegido
-            new DataBaseWhere('idempresa', $this->idempresa),
-            
-            // Para buscar ftras (de clientes o de Proveedores) que tengan IRPF
-            // new DataBaseWhere('totalirpf', 0.0, '!=') ... lo quitamos porque el modelo 130 es el cálculo total de ftras ventas (todas) menos el total de ftras. compras/gastos * 20%
+            new DataBaseWhere('idempresa', $this->idempresa),            
         ];
         
        
@@ -262,7 +256,6 @@ class Modelo130 extends Controller
         $order = ['fecha' => 'ASC', 'numero' => 'ASC'];
         
         // Cargamos primero las facturas de proveedores
-        // $this->invoices = $ftrasProveedores->all($where, $order, 0, 0);
         $this->customerInvoices = $ftrasProveedores->all($whereFtrasProveedores, $order, 0, 0);
 
         // Cargamos ahora las facturas de clientes
@@ -271,17 +264,14 @@ class Modelo130 extends Controller
 	
     protected function loadAsientos()
     {		
-		if (empty($this->codejercicio)) {
-            return;
-        }
 		
 		$codsubs = ['6420000000', '4730000000']; // 6420000000 Seguridad social , 4730000000 IRPF
 		
 		// Buscar asientos entre las fechas de los tipos anteriores, que el tipodocumento sea NULL ya que la partida 473
-		// también asocia facturas con retención aplicada que no deseamos aplicar, que ya se obtienen al consultar las facturas
+		// también asocia facturas con retención aplicada que no deseamos obtener, que ya se obtienen al consultar las facturas
 		$sql = 'SELECT * FROM ' . Partida::tableName() . ' as p'
             . ' LEFT JOIN ' . Asiento::tableName() . ' as a ON p.idasiento = a.idasiento'
-            . ' WHERE a.codejercicio = ' . $this->dataBase->var2str($this->codejercicio)
+            . ' WHERE a.idempresa = ' . $this->dataBase->var2str($this->idempresa)
             . ' AND a.fecha BETWEEN ' . $this->dataBase->var2str($this->dateStart) . ' AND ' . $this->dataBase->var2str($this->dateEnd)
 			. ' AND a.tipodocumento IS NULL'
             . ' AND p.codsubcuenta IN (' . \implode(',', $codsubs) . ')'
@@ -314,20 +304,19 @@ class Modelo130 extends Controller
 		// La seguridad social se cuenta como un gasto deducible
 		$this->taxbaseGastos += $this->segSocial;
 
+		// Primero calculamos rendimiento neto: ingresos(ftras ventas) - gastos (ftras compras/gastos + SS) acumulado anual
+		// El cálculo nos dará un número negativo o positivo que serán las pérdidas o los beneficios respectivamente
+		// El importe a deducir debe ser del 20% según modelo 130 o superior si se desea ingresar un IRPF superior
+		// Después se deben restar las retenciones aplicadas en las facturas de venta ya que eso lo ingresa el cliente en tu nombre
+		// Igualmente como es el acumulado del año, se deben restar también los trimestrales ya pagados y registrado el asiento
+		// Si sale número negativo, el importe a ingresar este trimestra será 0
+		// Si sale positivo, dicha cantidad es la que corresponde ingresar y rellenando las casillas de Hacienda de acuerdo a los campos mostrados
+		// Habría que ver la posibilidad de añadir un botón para agregar el asiento de pago de cara a siguientes trimestres (el plugin no lo hace)
+		// Actualmente los asientos de Seguridad Social (642) y de trimestres anteriores (473) se mete a mano (una forma rápida es con el plugin Asientos Predefinidos)
+		// En este link se explica como calcular el modelo 130 
+		// https://tuspapelesautonomos.es/modelo-130-como-se-calcula-descubrelo-facil-con-ejemplos/
 
 		$this->taxbase = round( $this->taxbaseIngresos - $this->taxbaseGastos, 2);
-
-     // Primero calculamos rendimiento neto: ingresos(ftras ventas) - gastos (ftras compras/gastos + SS) acumulado anual
-     // El cálculo nos dará un número negativo o positivo que serán las pérdidas o los beneficios respectivamente
-	 // El importe a deducir debe ser del 20% según modelo 130 o superior si se desea ingresar un IRPF superior
-	 // Después se deben restar las retenciones aplicadas en las facturas ya que eso lo ingresa el cliente en tu nombre
-	 // Y igualmente como es el acumulado del año, se deben restar también los trimestrales ya pagados y registrado el asiento
-     // Si sale número negativo, el importe a ingresar este trimestra será 0
-     // Si sale positivo, dicha cantidad es la corresponde ingresar y rellenar las casillas de Hacienda de acuerdo a los campos mostrados
-     // Habría que ver la posibilidad de añadir un botón para agregar el asiento de pago de cara a siguientes trimestres (el plugin no lo hace)
-	 // Actualmente los asientos de Seguridad Social y de trimestres anteriores se mete a mano (una forma rápida es con el plugin Asientos Predefinidos)
-     // En este link se explica como calcular el modelo 130 
-     // https://tuspapelesautonomos.es/modelo-130-como-se-calcula-descubrelo-facil-con-ejemplos/
         
         $this->todeduct = (float) $this->request->request->get('todeduct', $this->todeduct);
 		

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -267,8 +267,8 @@ class Modelo130 extends Controller
 		
 	$codsubs = ['6420000000', '4730000000']; // 6420000000 Seguridad social , 4730000000 IRPF
 		
-	// Buscar asientos entre las fechas de los tipos anteriores, que el tipodocumento sea NULL ya que la partida 473
-	// también asocia facturas con retención aplicada que no deseamos obtener, que ya se obtienen al consultar las facturas
+	// Buscar asientos entre las fechas de los tipos anteriores, la partida 473
+	// también obtiene las facturas con retención aplicada que se mostarán en asientos
 	$sql = 'SELECT * FROM ' . Partida::tableName() . ' as p'
             . ' LEFT JOIN ' . Asiento::tableName() . ' as a ON p.idasiento = a.idasiento'
             . ' WHERE a.idempresa = ' . $this->dataBase->var2str($this->idempresa)
@@ -290,7 +290,7 @@ class Modelo130 extends Controller
         
         foreach ($this->supplierInvoices as $invoice) {
             $this->taxbaseIngresos += $invoice->neto;
-			$this->taxbaseRetenciones += $invoice->totalirpf;
+	    $this->taxbaseRetenciones += $invoice->totalirpf;
         }
 		
 	foreach ($this->accountingAsientos as $asiento) {
@@ -303,6 +303,10 @@ class Modelo130 extends Controller
 		
 	// La seguridad social se cuenta como un gasto deducible
 	$this->taxbaseGastos += $this->segSocial;
+	    
+	// La partida 473 incluye tanto trimestres anteriores como las retenciones de facturas
+	$this->positivosTrimestres = round( $this->positivosTrimestres - $this->taxbaseRetenciones, 2);
+	
 
 	// Primero calculamos rendimiento neto: ingresos(ftras ventas) - gastos (ftras compras/gastos + SS) acumulado anual
 	// El cálculo nos dará un número negativo o positivo que serán las pérdidas o los beneficios respectivamente

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -317,13 +317,16 @@ class Modelo130 extends Controller
 
 		$this->taxbase = round( $this->taxbaseIngresos - $this->taxbaseGastos, 2);
 
-     // Primero calculamos ingresos(ftras ventas) - gastos (ftras compras/gastos)
+     // Primero calculamos rendimiento neto: ingresos(ftras ventas) - gastos (ftras compras/gastos + SS) acumulado anual
      // El cálculo nos dará un número negativo o positivo que serán las pérdidas o los beneficios respectivamente
-     // Si salen pérdidas (resta = números negativos) el cálculo a deducir será 0
-     // Si salen beneficios, entonces será cuestión de calcular el % a deducir introducido sobre los beneficios
-     // Estos cálculos son sobre el trimestre, para calcularlo bien habría que ver lo que se ha calculado/declarado 
-     // de trimestres anteriores.
-     // En este link se explica mejor como calcular el modelo 130 
+	 // El importe a deducir debe ser del 20% según modelo 130 o superior si se desea ingresar un IRPF superior
+	 // Después se deben restar las retenciones aplicadas en las facturas ya que eso lo ingresa el cliente en tu nombre
+	 // Y igualmente como es el acumulado del año, se deben restar también los trimestrales ya pagados y registrado el asiento
+     // Si sale número negativo, el importe a ingresar este trimestra será 0
+     // Si sale positivo, dicha cantidad es la corresponde ingresar y rellenar las casillas de Hacienda de acuerdo a los campos mostrados
+     // Habría que ver la posibilidad de añadir un botón para agregar el asiento de pago de cara a siguientes trimestres (el plugin no lo hace)
+	 // Actualmente los asientos de Seguridad Social y de trimestres anteriores se mete a mano (una forma rápida es con el plugin Asientos Predefinidos)
+     // En este link se explica como calcular el modelo 130 
      // https://tuspapelesautonomos.es/modelo-130-como-se-calcula-descubrelo-facil-con-ejemplos/
         
         $this->todeduct = (float) $this->request->request->get('todeduct', $this->todeduct);

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -281,7 +281,8 @@ class Modelo130 extends Controller
             . ' LEFT JOIN ' . Asiento::tableName() . ' as a ON p.idasiento = a.idasiento'
             . ' WHERE a.codejercicio = ' . $this->dataBase->var2str($this->codejercicio)
             . ' AND a.fecha BETWEEN ' . $this->dataBase->var2str($this->dateStart) . ' AND ' . $this->dataBase->var2str($this->dateEnd)
-            . ' AND p.codsubcuenta IN (' . \implode(',', $codsubs) . ')';
+            . ' AND p.codsubcuenta IN (' . \implode(',', $codsubs) . ')'
+			. ' ORDER BY numero ASC';
         foreach ($this->dataBase->select($sql) as $row) {
             $this->accountingAsientos[] = new Partida($row);
         }

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -32,6 +32,7 @@ use FacturaScripts\Dinamic\Model\Asiento;
  *
  * @author Carlos Garcia Gomez            <carlos@facturascripts.com>
  * @author Jerónimo Pedro Sánchez Manzano <socger@gmail.com>
+ * @author Javier Martín González <javier@javiermarting.es>
  */
 class Modelo130 extends Controller
 {

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -69,6 +69,12 @@ class Modelo130 extends Controller
      * @var FacturaCliente[]
      */
     public $supplierInvoices = [];
+	
+    /**
+     *
+     * @var Asientos[]
+     */
+    public $accountingAsientos = [];
 
     /**
      *
@@ -180,6 +186,7 @@ class Modelo130 extends Controller
         
         $this->loadDates(); // Traemos del codejercicio y period elegido idempresa, dateStart y dateEnd
         $this->loadInvoices(); // jerofa vas por aqui
+		$this->loadAsientos();
         $this->loadResults();
     }
 
@@ -257,6 +264,11 @@ class Modelo130 extends Controller
 
         // Cargamos ahora las facturas de clientes
         $this->supplierInvoices = $ftrasClientes->all($whereFtrasClientes, $order, 0, 0);
+    }
+	
+    protected function loadAsientos()
+    {
+		//TODO: Cargar asiento SegSocial (haber 4760000000) y Cargar asiento 130 (debe 4730000000 restando la variable retenciones ya que también aparecen en este asiento)
     }
     
     protected function loadResults()

--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -273,7 +273,6 @@ class Modelo130 extends Controller
             . ' LEFT JOIN ' . Asiento::tableName() . ' as a ON p.idasiento = a.idasiento'
             . ' WHERE a.idempresa = ' . $this->dataBase->var2str($this->idempresa)
             . ' AND a.fecha BETWEEN ' . $this->dataBase->var2str($this->dateStart) . ' AND ' . $this->dataBase->var2str($this->dateEnd)
-	    . ' AND a.tipodocumento IS NULL'
             . ' AND p.codsubcuenta IN (' . \implode(',', $codsubs) . ')'
 	    . ' ORDER BY numero ASC';
         foreach ($this->dataBase->select($sql) as $row) {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Modelo130
 Plugin para FacturaScripts con el modelo 130 para la hacienda española.
 
+El plugin tiene en cuenta para el cálculo las cuotas de autónomo de la Seguridad Social siempre y cuando estén añadidas en la subcuenta 642, así como los ingresados realizados en los pasados trimestres siempre y cuando estén añadidos en la subcuenta 473.
+
 # to download
-https://github.com/socger/Modelo130
 https://facturascripts.com/plugins/modelo130
 
 ## Issues / Feedback

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,7 +1,15 @@
 {
     "model-130": "Modelo 130",
     "model-130-p": "El Modelo 130 es una declaración trimestral del impuesto de la renta de las personas físicas (IRPF) en el que se liquida el pago fraccionado de este impuesto, a cuenta de la declaración anual que se realiza el año siguiente.",
-    "number-recipients": "Nº perceptores",
+    "model-130-r": "Datos acumulados del período comprendido entre el primer día del año y el último día del trimestre",
+	"tax-base": "B.Imp.",
+	"tax-incomes": "Ingresos computables",
+	"tax-expenses": "Gastos deducibles",
+	"net-total": "Rendimiento neto",
+	"retentions": "Retenciones soportadas",
     "%to-deduct": "% a deducir",
-    "tax-base": "B.Imp."
+	"after-deduct": "sobre casilla 04",
+	"previous-model": "Ingresos trimestres anteriores",
+	"result": "Total a ingresar",
+	"tax-negative-info": "Si da pérdidas (negativo) = 0"
 }

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -2,14 +2,14 @@
     "model-130": "Modelo 130",
     "model-130-p": "El Modelo 130 es una declaración trimestral del impuesto de la renta de las personas físicas (IRPF) en el que se liquida el pago fraccionado de este impuesto, a cuenta de la declaración anual que se realiza el año siguiente.",
     "model-130-r": "Datos acumulados del período comprendido entre el primer día del año y el último día del trimestre",
-	"tax-base": "B.Imp.",
-	"tax-incomes": "Ingresos computables",
-	"tax-expenses": "Gastos deducibles",
-	"net-total": "Rendimiento neto",
-	"retentions": "Retenciones soportadas",
+    "tax-base": "B.Imp.",
+    "tax-incomes": "Ingresos computables",
+    "tax-expenses": "Gastos deducibles",
+    "net-total": "Rendimiento neto",
+    "retentions": "Retenciones soportadas",
     "%to-deduct": "% a deducir",
-	"after-deduct": "sobre casilla 04",
-	"previous-model": "Ingresos trimestres anteriores",
-	"result": "Total a ingresar",
-	"tax-negative-info": "Si da pérdidas (negativo) = 0"
+    "after-deduct": "sobre casilla 04",
+    "previous-model": "Ingresos trimestres anteriores",
+    "result": "Total a ingresar",
+    "tax-negative-info": "Si da pérdidas (negativo) = 0"
 }

--- a/View/Modelo130.html.twig
+++ b/View/Modelo130.html.twig
@@ -72,6 +72,9 @@
                     <h2 class="h3 mt-3">
                         <i class="far fa-clipboard fa-fw"></i> {{ i18n.trans('summary') }} {#Resumen#}
                     </h2>
+					<p>
+                        {{ i18n.trans('model-130-r') }} {#Ponemos la parrafada de que es el modelo 130#}
+                    </p>
                 </div>
             </div>
 
@@ -79,36 +82,31 @@
             <div class="row">
                 <div class="col">
                     <div class="form-group">
-                        {{ i18n.trans('tax-base') }}
-                        -
-                        {{ i18n.trans('sales') }}
+                        {{ i18n.trans('tax-incomes') }}
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">01</span>
                             </div>
-                            <input type="number" value="{{ fsc.taxbaseFtrasClientes }}" class="form-control text-right" readonly="true" /> {#Base Imponible#}
+                            <input type="number" value="{{ fsc.taxbaseIngresos }}" class="form-control text-right" readonly="true" /> {#Base Imponible#}
                         </div>
                     </div>
                 </div>
 
                 <div class="col">
                     <div class="form-group">
-                        {{ i18n.trans('tax-base') }}
-                        -
-                        {{ i18n.trans('purchases') }}
+                        {{ i18n.trans('tax-expenses') }}
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">02</span>
                             </div>
-                            <input type="number" value="{{ fsc.taxbaseFtrasProveedores }}" class="form-control text-right" readonly="true" />
+                            <input type="number" value="{{ fsc.taxbaseGastos }}" class="form-control text-right" readonly="true" />
                         </div>
                     </div>
                 </div>
 
                 <div class="col">
                     <div class="form-group">
-                        {#{{ i18n.trans('tax-base') }}#}
-                        {{ i18n.trans('sales') }} - {{ i18n.trans('purchases') }}
+                        {{ i18n.trans('net-total') }}
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">03</span>
@@ -126,21 +124,59 @@
                         </div>
                     </div>
                 </div>
-                            
-                <div class="col">
+            </div>
+			
+			{#Segunda fila donde se calculará en rendimiento total#} 
+			<div class="row">
+				<div class="col">
                     <div class="form-group">
-                        {{ fsc.todeduct }}% sobre casilla 03
-                        {#{{ i18n.trans('result') }}#}
+                        {{ fsc.todeduct }}% {{ i18n.trans('after-deduct') }}
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">04</span>
                             </div>
-                            <input type="number" value="{{ fsc.result }}" class="form-control text-right" readonly="true" />
+                            <input type="number" value="{{ fsc.afterdeduct }}" class="form-control text-right" readonly="true" />
                         </div>
-                        Si da pérdidas (negativo) = 0
                     </div>
                 </div>
-            </div>
+				
+				<div class="col">
+                    <div class="form-group">
+                        {{ i18n.trans('retentions') }}
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">05</span>
+                            </div>
+                            <input type="number" value="{{ fsc.taxbaseRetenciones }}" class="form-control text-right" readonly="true" />
+                        </div>
+                    </div>
+                </div>
+				
+				<div class="col">
+                    <div class="form-group">
+                        {{ i18n.trans('previous-model') }}
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">06</span>
+                            </div>
+                            <input type="number" value="{{ fsc.positivosTrimestres }}" class="form-control text-right" readonly="true" />
+                        </div>
+                    </div>
+                </div>
+				
+				<div class="col">
+                    <div class="form-group">
+                        {{ i18n.trans('result') }}
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">07</span>
+                            </div>
+                            <input type="number" value="{{ fsc.result }}" class="form-control text-right" readonly="true" />
+                        </div>
+						{{ i18n.trans('tax-negative-info') }}
+                    </div>
+                </div>
+			</div>
 
             {#Creamos las pestañas de Ftras de clientes y proveedores#}
             <ul class="nav nav-tabs" id="myTab" role="tablist">

--- a/View/Modelo130.html.twig
+++ b/View/Modelo130.html.twig
@@ -126,9 +126,9 @@
                 </div>
             </div>
 			
-			{#Segunda fila donde se calculará en rendimiento total#} 
-			<div class="row">
-				<div class="col">
+	   {#Segunda fila donde se calculará en rendimiento total#} 
+	   <div class="row">
+		<div class="col">
                     <div class="form-group">
                         {{ fsc.todeduct }}% {{ i18n.trans('after-deduct') }}
                         <div class="input-group">
@@ -140,7 +140,7 @@
                     </div>
                 </div>
 				
-				<div class="col">
+		<div class="col">
                     <div class="form-group">
                         {{ i18n.trans('retentions') }}
                         <div class="input-group">
@@ -152,7 +152,7 @@
                     </div>
                 </div>
 				
-				<div class="col">
+		<div class="col">
                     <div class="form-group">
                         {{ i18n.trans('previous-model') }}
                         <div class="input-group">
@@ -164,7 +164,7 @@
                     </div>
                 </div>
 				
-				<div class="col">
+		<div class="col">
                     <div class="form-group">
                         {{ i18n.trans('result') }}
                         <div class="input-group">
@@ -173,10 +173,10 @@
                             </div>
                             <input type="number" value="{{ fsc.result }}" class="form-control text-right" readonly="true" />
                         </div>
-						{{ i18n.trans('tax-negative-info') }}
+			{{ i18n.trans('tax-negative-info') }}
                     </div>
                 </div>
-			</div>
+	    </div>
 
             {#Creamos las pestañas de Ftras de clientes y proveedores#}
             <ul class="nav nav-tabs" id="myTab" role="tablist">
@@ -306,10 +306,10 @@
                                         <thead>
                                             <tr>
                                                 <th>{{ i18n.trans('accounting-entry') }}</th>
-												<th>{{ i18n.trans('subaccount') }}</th>
-												<th>{{ i18n.trans('concept') }}</th>
-												<th class="text-right">{{ i18n.trans('total') }}</th>
-												<th class="text-right">{{ i18n.trans('date') }}</th>
+						<th>{{ i18n.trans('subaccount') }}</th>
+						<th>{{ i18n.trans('concept') }}</th>
+						<th class="text-right">{{ i18n.trans('total') }}</th>
+						<th class="text-right">{{ i18n.trans('date') }}</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -336,7 +336,6 @@
                     {#{% endif %}#}
                 </div>
             </div>                        
-
         </div>
     </form>
 {% endblock %}

--- a/View/Modelo130.html.twig
+++ b/View/Modelo130.html.twig
@@ -181,20 +181,25 @@
             {#Creamos las pestañas de Ftras de clientes y proveedores#}
             <ul class="nav nav-tabs" id="myTab" role="tablist">
                 <li class="nav-item" role="presentation">
-                    <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">
+                    <a class="nav-link active" id="sales-tab" data-toggle="tab" href="#sales" role="tab" aria-controls="sales" aria-selected="true">
                         <i class="far fa-copy fa-fw"></i> {{ i18n.trans('sales') }}
                     </a>
                 </li>
                 <li class="nav-item" role="presentation">
-                    <a class="nav-link" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">
+                    <a class="nav-link" id="purchases-tab" data-toggle="tab" href="#purchases" role="tab" aria-controls="purchases" aria-selected="false">
                         <i class="far fa-copy fa-fw"></i> {{ i18n.trans('purchases') }}
+                    </a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link" id="accounting-tab" data-toggle="tab" href="#accounting" role="tab" aria-controls="accounting" aria-selected="false">
+                        <i class="far fa-copy fa-fw"></i> {{ i18n.trans('accounting-entries') }}
                     </a>
                 </li>
             </ul>
 
             {#Creamos el contenido de las pestañas antes mencionadas#}
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                <div class="tab-pane fade show active" id="sales" role="tabpanel" aria-labelledby="sales-tab">
                     {#Presentamos las líneas de facturas de clientes cargadas desde Modelo130.php function loadInvoices()#}            
                     {#{% if fsc.customerInvoices is not empty %}#}
                         {#La fila de detalle de cada factura#}            
@@ -243,7 +248,7 @@
                     {#{% endif %}#}
                 </div>
 
-                <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">
+                <div class="tab-pane fade" id="purchases" role="tabpanel" aria-labelledby="purchases-tab">
                     {#Presentamos las líneas de facturas de proveedores cargadas desde Modelo130.php function loadInvoices()#}            
                     {#{% if fsc.supplierInvoices is not empty %}#}
                         {#La fila de detalle de cada factura#}            
@@ -276,6 +281,51 @@
                                                     <td class="text-right">{{ fsc.toolBox().coins().format(item.totalirpf) }}</td>
                                                     <td class="text-right">{{ fsc.toolBox().coins().format(item.total) }}</td>
                                                     <td class="text-right">{{ item.fecha }}</td>
+                                                </tr>
+                                            {% else %}
+                                                <tr class="table-warning">
+                                                    <td colspan="8">{{ i18n.trans('no-data') }}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    {#{% endif %}#}
+                </div>
+				
+                <div class="tab-pane fade" id="accounting" role="tabpanel" aria-labelledby="accounting-tab">
+                    {#Presentamos los asientos desde Modelo130.php function loadAsientos()#}            
+                    {#{% if fsc.accountingAsientos is not empty %}#}
+                        {#La fila de detalle de cada asiento#}            
+                        <div class="row">
+                            <div class="col">
+                                <div class="table-responsive">
+                                    <table class="table table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th>{{ i18n.trans('accounting-entry') }}</th>
+												<th>{{ i18n.trans('subaccount') }}</th>
+												<th>{{ i18n.trans('counterpart') }}</th>
+												<th>{{ i18n.trans('concept') }}</th>
+												<th class="text-right">{{ i18n.trans('debit') }}</th>
+												<th class="text-right">{{ i18n.trans('credit') }}</th>
+												<th class="text-right">{{ i18n.trans('date') }}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for item in fsc.accountingAsientos %}
+                                                <tr>
+                                            <td>
+                                                <a href="{{ item.url() }}">{{ item.numero }}</a>
+                                            </td>
+                                            <td>{{ item.codsubcuenta }}</td>
+                                            <td>{{ item.codcontrapartida }}</td>
+                                            <td>{{ item.concepto | raw }}</td>
+                                            <td class="text-right">{{ fsc.toolBox().coins().format(item.debe) }}</td>
+                                            <td class="text-right">{{ fsc.toolBox().coins().format(item.haber) }}</td>
+                                            <td class="text-right">{{ item.fecha }}</td>
                                                 </tr>
                                             {% else %}
                                                 <tr class="table-warning">

--- a/View/Modelo130.html.twig
+++ b/View/Modelo130.html.twig
@@ -307,10 +307,8 @@
                                             <tr>
                                                 <th>{{ i18n.trans('accounting-entry') }}</th>
 												<th>{{ i18n.trans('subaccount') }}</th>
-												<th>{{ i18n.trans('counterpart') }}</th>
 												<th>{{ i18n.trans('concept') }}</th>
-												<th class="text-right">{{ i18n.trans('debit') }}</th>
-												<th class="text-right">{{ i18n.trans('credit') }}</th>
+												<th class="text-right">{{ i18n.trans('total') }}</th>
 												<th class="text-right">{{ i18n.trans('date') }}</th>
                                             </tr>
                                         </thead>
@@ -321,10 +319,8 @@
                                                 <a href="{{ item.url() }}">{{ item.numero }}</a>
                                             </td>
                                             <td>{{ item.codsubcuenta }}</td>
-                                            <td>{{ item.codcontrapartida }}</td>
                                             <td>{{ item.concepto | raw }}</td>
                                             <td class="text-right">{{ fsc.toolBox().coins().format(item.debe) }}</td>
-                                            <td class="text-right">{{ fsc.toolBox().coins().format(item.haber) }}</td>
                                             <td class="text-right">{{ item.fecha }}</td>
                                                 </tr>
                                             {% else %}

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,4 +1,4 @@
 description = 'Modelo 130'
 min_version = 2021
 name = Modelo130
-version = 2.5
+version = 3.0


### PR DESCRIPTION
- Modelo 130 obteniendo facturas desde el inicio del año y no solo del trimestre elegido, así como descripción copia/pega de Hacienda explicando que el modelo es un acumulativo

- Modificados textos explicativos de campos para adaptarse al modelo así como traducciones (eliminando variable del 111 que aquí no se usaba y añadiendo otras traducciones que estaban directamente en el código)

- Agregados nuevos campos presentes del modelo (rendimiento neto, tras aplicar %, retenciones soportadas y ingresos de trimestres anteriores)

- Modificada fórmula para tener en cuenta la seguridad social como gastos deducibles, las retenciones soportadas y los trimestres anteriores positivos

- Modificadas nombres de tabs con nombres reales de la tab, no como "home" / "profile" que no indicaba realmente lo que es

- Añadida tab de asientos para desglosar la Seguridad Social y trimestres anteriores que está computando

- Consulta similar a la ya hecha en Modelo 111, pero en este caso para obtener las subcuentas de Seguridad Social (642) y de IRPF (473)

- Modificación de la explicación de qué hace el plugin de acuerdo al nuevo comportamiento y la carencia faltante

- Removidos comentarios de lógica del código que pertenecen a la lógica del 111 y no del 130