### PR TITLE
Añadir justificación de gastos en Modelo 130

### DIFF
--- a/Controller/Modelo130.php
+++ b/Controller/Modelo130.php
@@ -50,6 +50,12 @@ class Modelo130 extends Controller
     /** @var string */
     public $activeTab = '';
 
+    /** @var bool */
+    public $applyGastosJustificacion = false;
+
+    /** @var float */
+    public $gastosJustificacion = 0.0;
+
     /** @var string */
     public $codejercicio;
 
@@ -428,9 +434,14 @@ class Modelo130 extends Controller
 
         $this->taxbase = round($this->taxbaseIngresos - $this->taxbaseGastos, 2);
 
+        $this->applyGastosJustificacion = '1' === $this->request->request->get('gastosJustificacion', '0');
+        if ($this->applyGastosJustificacion && $this->taxbase > 0) {
+            $this->gastosJustificacion = round($this->taxbase * 0.05, 2);
+        }
+
         $this->todeduct = (float)$this->request->request->get('todeduct', $this->todeduct);
 
-        $this->afterdeduct = round(($this->taxbase * $this->todeduct) / 100, 2);
+        $this->afterdeduct = round((($this->taxbase - $this->gastosJustificacion) * $this->todeduct) / 100, 2);
 
         $this->result = round($this->afterdeduct - $this->taxbaseRetenciones - $this->positivosTrimestres, 2);
 

--- a/Test/main/Modelo130ControllerTest.php
+++ b/Test/main/Modelo130ControllerTest.php
@@ -62,6 +62,40 @@ final class Modelo130ControllerTest extends TestCase
         $this->assertSame("'6400000000','9999.1'", $controller->sqlValueList(['6400000000', '9999.1']));
     }
 
+    public function testGastosJustificacionCalculaEl5PorCiento(): void
+    {
+        $controller = new Modelo130TestAccess(Modelo130TestAccess::class);
+        $controller->calcularGastos(10000, 2500, true);
+
+        $this->assertEquals(375.0, $controller->gastosJustificacion);
+    }
+
+    public function testGastosJustificacionEsCeroSiRendimientoNegativo(): void
+    {
+        $controller = new Modelo130TestAccess(Modelo130TestAccess::class);
+        $controller->calcularGastos(1000, 5000, true);
+
+        $this->assertEquals(0.0, $controller->gastosJustificacion);
+    }
+
+    public function testGastosJustificacionDesactivadoNoAfectaAfterdeduct(): void
+    {
+        $controller = new Modelo130TestAccess(Modelo130TestAccess::class);
+        $controller->calcularGastos(10000, 2500, false);
+
+        $this->assertEquals(0.0, $controller->gastosJustificacion);
+        $this->assertEquals(round(7500 * 0.20, 2), $controller->afterdeduct);
+    }
+
+    public function testAfterdeductSeCalculaSobreBaseReducida(): void
+    {
+        $controller = new Modelo130TestAccess(Modelo130TestAccess::class);
+        $controller->calcularGastos(10000, 2500, true);
+
+        // taxbase = 7500, gastosJustificacion = 375, base = 7125, afterdeduct = 7125 * 20% = 1425
+        $this->assertEquals(1425.0, $controller->afterdeduct);
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();
@@ -83,5 +117,17 @@ class Modelo130TestAccess extends Modelo130
     public function sqlValueList(array $values): string
     {
         return $this->getSqlValueList($values);
+    }
+
+    public function calcularGastos(float $ingresos, float $gastos, bool $apply): void
+    {
+        $this->taxbaseIngresos = $ingresos;
+        $this->taxbaseGastos = $gastos;
+        $this->taxbase = round($ingresos - $gastos, 2);
+        $this->applyGastosJustificacion = $apply;
+        if ($apply && $this->taxbase > 0) {
+            $this->gastosJustificacion = round($this->taxbase * 0.05, 2);
+        }
+        $this->afterdeduct = round((($this->taxbase - $this->gastosJustificacion) * $this->todeduct) / 100, 2);
     }
 }

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,6 +1,8 @@
 {
     "after-deduct": "sobre casilla 04",
     "deductible-subaccounts": "Cuentas deducibles",
+    "gastos-justificacion": "Gastos de difícil justificación (5%)",
+    "gastos-justificacion-limit": "Atención: el importe supera el límite anual de 2.000 €",
     "model-130": "Modelo 130",
     "model-130-desc": "Se calcula sumando y acumulando cada trimestre, por ejemplo, si visualizamos el 3º trimestre veremos la suma de los trimestres 1, 2 y 3.",
     "model-130-p": "El Modelo 130 es una declaración trimestral del impuesto de la renta de las personas físicas (IRPF) en el que se liquida el pago fraccionado de este impuesto, a cuenta de la declaración anual que se realiza el año siguiente.",

--- a/View/Modelo130.html.twig
+++ b/View/Modelo130.html.twig
@@ -144,6 +144,28 @@
                 </div>
                 <div class="col-sm-6 col-md-4 col-lg-3">
                     <div class="mb-3">
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input" id="gastosJustificacion"
+                                   name="gastosJustificacion" value="1"
+                                   onchange="this.form.submit();"
+                                   {{ fsc.applyGastosJustificacion ? 'checked' : '' }}>
+                            <label class="form-check-label" for="gastosJustificacion">
+                                {{ trans('gastos-justificacion') }}
+                            </label>
+                        </div>
+                        <div class="input-group">
+                            <input type="number" value="{{ fsc.gastosJustificacion }}" class="form-control text-end"
+                                   readonly/>
+                        </div>
+                        {% if fsc.gastosJustificacion > 2000 %}
+                            <p class="form-text text-warning fw-bold">
+                                <i class="fa-solid fa-triangle-exclamation me-1"></i>{{ trans('gastos-justificacion-limit') }}
+                            </p>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="col-sm-6 col-md-4 col-lg-3">
+                    <div class="mb-3">
                         {{ trans('pct-to-deduct') }}
                         <div class="input-group">
                             <input type="number" name="todeduct" min="0" max="100" value="{{ fsc.todeduct }}"


### PR DESCRIPTION
https://facturascripts.com/roadmap/4079
- Se ha añadido un nuevo checkbox en Modelo130.html.twig para activar la justificación de gastos.
- Se han agregado nuevos campos en es_ES.json para la justificación de gastos.
- Se ha implementado la lógica para calcular el 5% de los gastos justificados en Modelo130.php.
- Se han creado pruebas en Modelo130ControllerTest.php para verificar el cálculo de gastos justificados y su impacto en el monto a deducir.

Estos cambios permiten a los usuarios justificar gastos y calcular su impacto en la declaración.